### PR TITLE
Typo correction

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@ var humanizeTitleMap = {
   imageResponseBytes: 'Image size',
   javascriptResponseBytes: 'JavaScript size',
   otherResponseBytes: 'Other size',
-  numberJsResources: 'JS resouces',
+  numberJsResources: 'JS resources',
   numberCssResources: 'CSS resources',
   AvoidLandingPageRedirects: 'Avoid landing page redirects',
   AvoidPlugins: 'Avoid plugins',


### PR DESCRIPTION
Not code changed, just spelling; "JS resouces" is now "JS resources"