### PR TITLE
Enable display of usability scores

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -9,7 +9,7 @@ var pify = require('pify');
 var THRESHOLD = 70;
 var RESOURCE_URL = 'https://developers.google.com/speed/pagespeed/insights/optimizeContents?';
 
-function overview(url, strategy, score) {
+function overview(url, strategy, scores) {
   var ret = [];
 
   ret.push({
@@ -23,9 +23,16 @@ function overview(url, strategy, score) {
   });
 
   ret.push({
-    label: 'Score',
-    value: score
+    label: 'Speed',
+    value: scores.SPEED.score
   });
+
+  if (scores.USABILITY !== undefined) {
+    ret.push({
+      label: 'Usability',
+      value: scores.USABILITY.score
+    });
+  }
 
   return ret;
 }
@@ -72,7 +79,7 @@ module.exports = function (parameters, response) {
     var optimizedResoruceURL = RESOURCE_URL + querystring.stringify({url: response.id, strategy: parameters.strategy});
 
     console.log(renderer(
-      overview(humanizeUrl(response.id), parameters.strategy, response.ruleGroups.SPEED.score),
+      overview(humanizeUrl(response.id), parameters.strategy, response.ruleGroups),
       statistics(response.pageStats),
       ruleSetResults(response.formattedResults.ruleResults),
       threshold

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe('Formatting', function () {
 
   it('should correctly format PageSpeed Insights response', function () {
     return output({strategy: 'desktop'}, response).then(function () {
-      assert(/Score: +88/.test(chalk.stripColor(this.formattedOutput)));
+      assert(/Speed: +88/.test(chalk.stripColor(this.formattedOutput)));
     }.bind(this));
   });
 
@@ -34,7 +34,7 @@ describe('Formatting', function () {
 
   it('should format PageSpeed Insights response as JSON output', function () {
     return output({strategy: 'desktop', format: 'json'}, response).then(function () {
-      assert(/"Score": 88/.test(chalk.stripColor(this.formattedOutput)));
+      assert(/"Speed": 88/.test(chalk.stripColor(this.formattedOutput)));
     }.bind(this));
   });
 


### PR DESCRIPTION
In V2, we switched over to the newer PageSpeed Insights API that included usability scoring but didn't update PSI's output to include this score. I've added this in.

After this change:

<img width="487" alt="screen shot 2015-11-10 at 16 37 30" src="https://cloud.githubusercontent.com/assets/110953/11068496/73c29f7e-87c9-11e5-8de5-7f4262e0d52e.png">
