### PR TITLE
Adding environment variable GOOGLE_API_KEY support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,9 @@ var cli = meow([
   '  --locale     Locale results should be generated in.',
   '  --threshold  Threshold score to pass the PageSpeed test.',
   '  --optimized  Get the URL of optimized resources.',
-  '  --download   Download optimized resources.'
+  '  --download   Download optimized resources.',
+  '',
+  'The environment variable GOOGLE_API_KEY can hold can hold a default API key.'
 ]);
 
 updateNotifier({pkg: cli.pkg}).notify();

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var output = require('./lib/output');
 
 function handleOpts(url, opts) {
   opts = objectAssign({strategy: 'mobile'}, opts);
+  // The environment variable GOOGLE_API_KEY can hold a default API key
+  if (process.env.GOOGLE_API_KEY) {
+    opts = objectAssign({key: process.env.GOOGLE_API_KEY}, opts);
+  }
   opts.nokey = opts.key === undefined;
   opts.url = prependHttp(url);
   return opts;


### PR DESCRIPTION
Allows users to define a global variable which holds the Google API key.

It may be preferable to set an environmental variable (`PSI` perhaps) that would set any/all default options.
