### PR TITLE
Update googleapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "download": "^4.4.1",
-    "googleapis": "^2.1.6",
+    "googleapis": "^7.1.0",
     "humanize-url": "^1.0.1",
     "lodash": "^4.5.1",
     "meow": "^3.5.0",


### PR DESCRIPTION
Hello!!

Update  googleapi to 7.1.0 for this reason:

* A potential remote memory exposure [vulnerability exists in request](https://snyk.io/vuln/npm:request:20160119)  <2.68.0 >2.2.5

* [googleapis@2.16](https://github.com/google/google-api-nodejs-client/blob/v2.1.6/package.json) use request@2.6.5.0

Running test OK, but there are several important change