### PR TITLE
Support a threshold of 0

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -75,7 +75,10 @@ function getReporter(format) {
 module.exports = function (parameters, response) {
   return Promise.resolve().then(function () {
     var renderer = getReporter(parameters.format);
-    var threshold = parameters.threshold || THRESHOLD;
+    var threshold = THRESHOLD;
+    if (parameters.threshold === 0 || parameters.threshold) {
+      threshold = parameters.threshold;
+    }
     var optimizedResourceURL = RESOURCE_URL + querystring.stringify({url: response.id, strategy: parameters.strategy});
 
     console.log(renderer(


### PR DESCRIPTION
Presently a threshold argument of zero passed via CLI is treated as though none was provided. 

e.g.
 
```
psi --threshold="0" url
# or
psi --threshold=0 url
```