### PR TITLE
Add option to format output for Prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.DS_Store

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ const cli = meow(`
   Options
     --key        Google API Key. By default the free tier is used
     --strategy   Strategy to use when analyzing the page: mobile|desktop
-    --format     Output format: cli|json|tap
+    --format     Output format: cli|json|prometheus|tap
     --locale     Locale results should be generated in
     --threshold  Threshold score to pass the PageSpeed test
     --optimized  Get the URL of optimized resources

--- a/lib/formats/prometheus.js
+++ b/lib/formats/prometheus.js
@@ -1,0 +1,29 @@
+'use strict';
+const _ = require('lodash');
+const bytes = require('bytes');
+const utils = require('../utils');
+
+module.exports = (overview, statistics, ruleSetResults) => {
+  const renderSection = (item, prefix) => {
+    const metric = prefix + utils.camelToSnake(item.label);
+    const value = metric.endsWith('_bytes') ? bytes(item.value) : item.value;
+
+    if (typeof value !== 'number') {
+      return null;
+    }
+
+    const x = ['# TYPE ' + metric + ' gauge', metric + ' ' + value].join('\n');
+    console.log(x)
+    return x
+  };
+
+  const renderOverview = section => { renderSection(section, 'psi_overview_') };
+  const renderStats = section => { renderSection(section, 'psi_stats_') };
+  const renderRules = section => { renderSection(section, 'psi_rules_') };
+
+  return [
+    _.map(overview, renderOverview).join('\n'),
+    _.map(statistics, renderStats).join('\n'),
+    _.map(ruleSetResults.filter(x => x.value > 0), renderRules).join('\n'),
+  ].join('\n').trim();
+};

--- a/lib/formats/prometheus.js
+++ b/lib/formats/prometheus.js
@@ -12,14 +12,15 @@ module.exports = (overview, statistics, ruleSetResults) => {
       return null;
     }
 
-    const x = ['# TYPE ' + metric + ' gauge', metric + ' ' + value].join('\n');
-    console.log(x)
-    return x
+    return [
+      '# TYPE ' + metric + ' gauge',
+      metric + ' ' + value
+    ].join('\n');
   };
 
-  const renderOverview = section => { renderSection(section, 'psi_overview_') };
-  const renderStats = section => { renderSection(section, 'psi_stats_') };
-  const renderRules = section => { renderSection(section, 'psi_rules_') };
+  const renderOverview = section => { return renderSection(section, 'psi_overview_') };
+  const renderStats = section => { return renderSection(section, 'psi_stats_') };
+  const renderRules = section => { return renderSection(section, 'psi_rules_') };
 
   return [
     _.map(overview, renderOverview).join('\n'),

--- a/lib/output.js
+++ b/lib/output.js
@@ -68,7 +68,7 @@ function statistics(stats) {
 }
 
 function getReporter(format) {
-  format = ['cli', 'json', 'tap'].indexOf(format) === -1 ? 'cli' : format;
+  format = ['cli', 'json', 'tap', 'prometheus'].indexOf(format) === -1 ? 'cli' : format;
   return require(`./formats/${format}`); // eslint-disable-line import/no-dynamic-require
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,3 +59,9 @@ exports.labelize = str => {
   const label = humanizeTitleMap[str] || str;
   return label + exports.buffer(label) + chalk.grey('| ');
 };
+
+exports.camelToSnake = str => {
+  return str.replace(/([a-z]|(?:[A-Z0-9]+))([A-Z0-9]|$)/g, function(_, $1, $2) {
+    return $1 + ($2 && '_' + $2);
+  }).toLowerCase()
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "size"
   ],
   "dependencies": {
+    "bytes": "^3.0.0",
     "chalk": "^2.3.0",
     "download": "^4.4.1",
     "googleapis": "^24.0.0",


### PR DESCRIPTION
This adds the ability to format the output for a Prometheus scraper, useful for piping to the [Prometheus pushgateway](https://github.com/prometheus/pushgateway) in our case.

For example:

```
$ psi --format=prometheus google.com
# TYPE psi_overview_speed gauge
psi_overview_speed 79
# TYPE psi_overview_usability gauge
psi_overview_usability 100
# TYPE psi_stats_css_response_bytes gauge
psi_stats_css_response_bytes 14438
# TYPE psi_stats_html_response_bytes gauge
psi_stats_html_response_bytes 118784
# TYPE psi_stats_image_response_bytes gauge
psi_stats_image_response_bytes 34816
# TYPE psi_stats_javascript_response_bytes gauge
psi_stats_javascript_response_bytes 631808
# TYPE psi_stats_number_css_resources gauge
psi_stats_number_css_resources 1
# TYPE psi_stats_number_hosts gauge
psi_stats_number_hosts 5
# TYPE psi_stats_number_js_resources gauge
psi_stats_number_js_resources 4
# TYPE psi_stats_number_resources gauge
psi_stats_number_resources 17
# TYPE psi_stats_number_static_resources gauge
psi_stats_number_static_resources 13
# TYPE psi_stats_other_response_bytes gauge
psi_stats_other_response_bytes 2099
# TYPE psi_stats_total_request_bytes gauge
psi_stats_total_request_bytes 2723
# TYPE psi_rules_avoid_landing_page_redirects gauge
psi_rules_avoid_landing_page_redirects 25.5
# TYPE psi_rules_main_resource_server_response_time gauge
psi_rules_main_resource_server_response_time 0.17
```