### PR TITLE
Require Node.js 6 and use pagespeed v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 yarn.lock
+.idea/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules
 yarn.lock
-.idea/
-.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
-const {google} = require('googleapis');
+const googleapis = require('googleapis');
 const prependHttp = require('prepend-http');
 const pify = require('pify');
 const output = require('./lib/output');
 
-const pagespeed = pify(google.pagespeedonline('v4').pagespeedapi);
+const pagespeed = pify(googleapis.google.pagespeedonline('v4').pagespeedapi);
 
 function handleOpts(url, opts) {
   opts = Object.assign({strategy: 'mobile'}, opts);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
-const googleapis = require('googleapis');
+const {google} = require('googleapis');
 const prependHttp = require('prepend-http');
 const pify = require('pify');
 const output = require('./lib/output');
 
-const pagespeed = pify(googleapis.pagespeedonline('v2').pagespeedapi.runpagespeed);
+const pagespeed = pify(google.pagespeedonline('v4').pagespeedapi);
 
 function handleOpts(url, opts) {
   opts = Object.assign({strategy: 'mobile'}, opts);
@@ -18,9 +18,9 @@ const psi = (url, opts) => Promise.resolve().then(() => {
     throw new Error('URL required');
   }
 
-  return pagespeed(handleOpts(url, opts));
+  return pagespeed.runpagespeed(handleOpts(url, opts));
 });
 
 module.exports = psi;
 
-module.exports.output = (url, opts) => psi(url, opts).then(data => output(handleOpts(url, opts), data));
+module.exports.output = (url, opts) => psi(url, opts).then(data => output(handleOpts(url, opts), data.data));

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "download": "^4.4.1",
-    "googleapis": "33.0.0",
+    "googleapis": "^33.0.0",
     "humanize-url": "^1.0.1",
     "lodash": "^4.5.1",
     "meow": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "bin": "cli.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && mocha"
@@ -34,11 +34,11 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "download": "^4.4.1",
-    "googleapis": "^24.0.0",
+    "googleapis": "33.0.0",
     "humanize-url": "^1.0.1",
     "lodash": "^4.5.1",
-    "meow": "^4.0.0",
-    "pify": "^3.0.0",
+    "meow": "^5.0.0",
+    "pify": "^4.0.0",
     "prepend-http": "^2.0.0",
     "pretty-bytes": "^4.0.2",
     "sort-on": "^2.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -51,13 +51,13 @@ describe('API', function () {
 
   it('should get data from PageSpeed Insights', () => {
     return psi('google.com').then(data => {
-      assert.strictEqual(data.title, 'Google');
+      assert.strictEqual(data.data.title, 'Google');
     });
   });
 
   it('should support options', () => {
     return psi('google.com', {locale: 'no'}).then(data => {
-      assert.strictEqual(data.formattedResults.locale, 'no');
+      assert.strictEqual(data.data.formattedResults.locale, 'no');
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -50,13 +50,13 @@ describe('API', function () {
   this.timeout(50000);
 
   it('should get data from PageSpeed Insights', () => {
-    return psi('https://www.google.com').then(data => {
-      assert.strictEqual(data.data.title, 'Google');
+    return psi('addyosmani.com/').then(data => {
+      assert.strictEqual(data.data.title, 'AddyOsmani.com');
     });
   });
 
   it('should support options', () => {
-    return psi('https://www.google.com', {locale: 'no'}).then(data => {
+    return psi('addyosmani.com/', {locale: 'no'}).then(data => {
       assert.strictEqual(data.data.formattedResults.locale, 'no');
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ describe('Formatting', () => {
 });
 
 describe('API', function () {
-  this.timeout(50000);
+  this.timeout(60000);
 
   it('should get data from PageSpeed Insights', () => {
     return psi('google.com').then(data => {

--- a/test/test.js
+++ b/test/test.js
@@ -47,10 +47,12 @@ describe('Formatting', () => {
 });
 
 describe('API', function () {
-  this.timeout(60000);
+  this.timeout(50000);
 
   it('should get data from PageSpeed Insights', () => {
     return psi('google.com').then(data => {
+      // Trying to find error in travis :-/ REMOVE
+      console.log(`data.data 👉 ${JSON.stringify(data.data)}`);
       assert.strictEqual(data.data.title, 'Google');
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -50,15 +50,13 @@ describe('API', function () {
   this.timeout(50000);
 
   it('should get data from PageSpeed Insights', () => {
-    return psi('google.com').then(data => {
-      // Trying to find error in travis :-/ REMOVE
-      console.log(`data.data 👉 ${JSON.stringify(data.data)}`);
+    return psi('https://www.google.com').then(data => {
       assert.strictEqual(data.data.title, 'Google');
     });
   });
 
   it('should support options', () => {
-    return psi('google.com', {locale: 'no'}).then(data => {
+    return psi('https://www.google.com', {locale: 'no'}).then(data => {
       assert.strictEqual(data.data.formattedResults.locale, 'no');
     });
   });


### PR DESCRIPTION
* Updated minimum **node** version to **6**.
* **googleapis** module version to 33.0.0
* Fixed some tests that fails after update to the new pagespeed version. #

Seems that google redirects to a failure page when test are launched in travis. Due that the title doesn't match with the expected in the test so the test fails. Because of that I have changed the page setted in the test and now all test pass again.

<img width="362" alt="google page error" src="https://user-images.githubusercontent.com/1837650/45891231-5b229480-bdc5-11e8-9c04-d03a881e5322.png">

Best regards.

---

Closes #90